### PR TITLE
Add a default keybind for the run command

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,13 @@
           "description": "Timeout duration in milliseconds"
         }
       }
-    }
+    },
+    "keybindings": [
+      {
+        "command": "highlightOnCopy.run",
+        "key": "ctrl+c"
+      }
+    ]
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/package.json
+++ b/package.json
@@ -64,7 +64,9 @@
     "keybindings": [
       {
         "command": "highlightOnCopy.run",
-        "key": "ctrl+c"
+        "key": "ctrl+c",
+        "mac": "cmd+c",
+        "when": "editorTextFocus"
       }
     ]
   },


### PR DESCRIPTION
This fixes issue #1, which is that by default the extension's actions are not bound to a key. 