### PR TITLE
Add multi-cursor support

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,9 +12,6 @@ export function activate(context: vscode.ExtensionContext) {
         return; // No open text editor
       }
 
-      const selection = editor.selection;
-      const text = editor.document.getText(selection);
-
       const config = vscode.workspace.getConfiguration("highlightOnCopy");
 
       // Retrieve settings with automatic fallback to defaults defined in package.json
@@ -22,16 +19,13 @@ export function activate(context: vscode.ExtensionContext) {
       const backgroundColor = config.get("backgroundColor"); // Default is used if not set by user
       const timeout = config.get("timeout"); // Default is used if not set by user
 
-      // Copy to clipboard
-      await vscode.env.clipboard.writeText(text);
-
       // Apply decoration
       const decorationType = vscode.window.createTextEditorDecorationType({
         backgroundColor: backgroundColor as string,
         color: foregroundColor || undefined,
       });
 
-      editor.setDecorations(decorationType, [selection]);
+      editor.setDecorations(decorationType, [...editor.selections]);
 
       // Remove decoration after specified timeout
       setTimeout(() => {


### PR DESCRIPTION
This PR adds support for multiple cursors/selections:

![Code_mUWfkpMJwE](https://github.com/mguellsegarra/highlight-on-copy/assets/18042232/8350558e-b83f-48e1-af88-efa6b0934d8e)

# PLS READ

I also removed adding the selection to the clipboard. I strongly advise this for several reasons:

- just let the built-in copy command do it's job
- copying selections to the clipboard is actually somewhat complex, for example, this extension's existing behavior actually BREAKS copying multiple selections
- even if you put a ton of work into making your copy behave EXACTLY like the built-in behavior, what if that changes in the future? It's much wiser to not even mess with this and just focus on the highlighting
