### PR TITLE
Fix when expression in default keybind

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
         "command": "highlightOnCopy.run",
         "key": "ctrl+c",
         "mac": "cmd+c",
-        "when": "editorTextFocus && highlightOnCopy.init"
+        "when": "editorFocus && highlightOnCopy.init"
       }
     ]
   },


### PR DESCRIPTION
Using `editorTextFocus` actually causes the command to not fire for me. Switching it to `editorFocus` makes it works right.

Sorry for not testing the first PR correctly!