### PR TITLE
fix: highlight entire line when used on empty selection

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,8 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
+  vscode.commands.executeCommand("setContext", "highlightOnCopy.init", false);
+}
 
 function getSelections(editor: vscode.TextEditor): readonly vscode.Selection[] | vscode.Range[] {
   const selections = editor.selections;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ export function activate(context: vscode.ExtensionContext) {
       });
 
       // Apply decoration
-      editor.setDecorations(decorationType, [...editor.selections]);
+    editor.setDecorations(decorationType, getSelections(editor));
 
       // Remove decoration after specified timeout
       setTimeout(() => {
@@ -42,5 +42,11 @@ export function activate(context: vscode.ExtensionContext) {
 }
 
 export function deactivate() {
-  vscode.commands.executeCommand("setContext", "highlightOnCopy.init", false);
+
+function getSelections(editor: vscode.TextEditor): readonly vscode.Selection[] | vscode.Range[] {
+  const selections = editor.selections;
+  if (selections.length === 1 && selections[0].isEmpty) {
+    return [editor.document.lineAt(selections[0].anchor).range];
+  }
+  return selections;
 }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -35,6 +35,31 @@ suite("Extension Test Suite", () => {
     );
   });
 
+  test("Copy and highlight command effectively updates the clipboard for an empty selection", async () => {
+    const document = await vscode.workspace.openTextDocument({
+      content: "Test text to be copied",
+    });
+
+    // Show the text document in the editor
+    const editor = await vscode.window.showTextDocument(document);
+
+    // Select the full text in the editor
+    const firstLine = editor.document.lineAt(0);
+    editor.selection = new vscode.Selection(firstLine.range.start, firstLine.range.end);
+
+    // Execute the command
+    await vscode.commands.executeCommand("highlightOnCopy.run");
+
+    // Get the paste content
+    const clipboardContent = await vscode.env.clipboard.readText();
+
+    assert.strictEqual(
+      clipboardContent,
+      document.getText(),
+      "The clipboard content should match the text in the editor."
+    );
+  });
+
   test("Multi-cursor copy command effectively updates the clipboard", async () => {
     // Create a new text document with multiple lines
     const document = await vscode.workspace.openTextDocument({


### PR DESCRIPTION
Executing a copy command with no selection copies the entire line. This fix enables decorations (highlight) in that case, and adds a test for that scenario