### PR TITLE
Multi-line cursor empty selections

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -49,9 +49,20 @@ export function getSelections(
   editor: vscode.TextEditor
 ): readonly vscode.Selection[] | vscode.Range[] {
   let lastSelectionLine = -1;
-  const expandedSelections = editor.selections.map((selection) => {
+
+  // We need to sort the selections for the case where an additional cursor is inserted
+  // before the 'active' cursor of another selection on the same line.
+  const sortedSelections = [...editor.selections].sort((a, b) => {
+    if (a.active.line === b.active.line) {
+      return a.active.character - b.active.character;
+    }
+    return a.active.line - b.active.line;
+  });
+
+  const expandedSelections = sortedSelections.map((selection) => {
     // With multiple cursors on a single line, any empty selection is ignored (after the first selection)
     if (selection.isEmpty && lastSelectionLine === selection.active.line) {
+      // We don't worry about setting lastSelectionLine here as this branch is only for the matching line
       return null;
     }
 


### PR DESCRIPTION
In my early PR #6 I didn't consider multiline cursors. This expands any empty selections to the whole line's range, but only if that matches the default copy behaviour.

The code for getting the expanded selections has become a bit more involved specifically to cover the case where there are 2 or more selections on the same line and there is an empty selection after another selection (empty or not). In that case, the empty selection is ignored. If the empty selection is the first selection on a line, default copy behaviour copies the entire line, a line break, and then the proceeding selection.

For example (selections denoted via comment below the line):
```
Text to copy
^__^     ^
```

In this case, where the empty selection was placed after `c`, it will be ignored. The sorting of selections is required to cover the case where the empty selection at `c` was placed before the other selection 
