### PR TITLE
fix: support untrustedWorkspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,11 @@
   "extensionKind": [
     "ui"
   ],
+  "capabilities": {
+    "untrustedWorkspaces": {
+      "supported": true
+    }
+  },
   "repository": {
     "url": "https://github.com/mguellsegarra/highlight-on-copy"
   },


### PR DESCRIPTION
 If you open a file in an untrusted workspace (normally when you open a file that is not in a project), the extension is disabled. This change makes it possible to use this extension in this case. 